### PR TITLE
Fix for running setup-mac from a symlink.

### DIFF
--- a/setup-mac
+++ b/setup-mac
@@ -10,8 +10,8 @@ set -e
 
 
 # Run in dotfiles folder
-cd "$(dirname "${BASH_SOURCE}")"
-
+REAL_PATH="$(readlink "${BASH_SOURCE}")"
+cd -P "$(dirname "${REAL_PATH}")"
 
 # Become super user before starting work
 sudo -v


### PR DESCRIPTION
Hi

I've symlinked setup-mac to a local bin directory and the current code would only go to the symlink directory, this works wherever the file is.